### PR TITLE
Update ChemProt_Gel_BCA_Normalization_Click_0718025.py

### DIFF
--- a/ChemProt_Gel_BCA_Normalization_Click_0718025.py
+++ b/ChemProt_Gel_BCA_Normalization_Click_0718025.py
@@ -395,6 +395,5 @@ def run(protocol: protocol_api.ProtocolContext):
                             mix_after=(3, 40), 
                             new_tip='always')
     thermocycler.close_lid()
-    thermocycler.set_block_temperature(95)  # Hold at 4°C
     protocol.delay(minutes=5)
     thermocycler.set_block_temperature(4)  # Hold at 4°C


### PR DESCRIPTION
Removed 95 C line because the thermocycler flashes yellow if you heat it too much. Then it won't work